### PR TITLE
Updates fetch efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/1.0.1..HEAD)
+## Unreleased - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/1.0.2..HEAD)
 
-## 1.0.1 - 2020-04-14 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/1.0.0..1.0.1)
+## 1.0.2 - 2021-04-28 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/1.0.1..1.0.2)
+
+- Update checkout to remain shallow
+- Update scan to fetch to only deepen to the necessary commits
+
+## 1.0.1 - 2021-04-14 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/1.0.0..1.0.1)
 
 - Update checkout with non-shallow
 
-## 1.0.0 - 2020-04-02 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/releases/tag/1.0.0)
+## 1.0.0 - 2021-04-02 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/releases/tag/1.0.0)
 
 - Initial Release

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Login to ECR
         uses: docker/login-action@v1
         with:

--- a/scan.sh
+++ b/scan.sh
@@ -124,12 +124,9 @@ main.run ()
   log.info "Initializing"
 
   if [ -n "${baseref:-}" ]; then
-    log.info "Base branch detected, fetching ${baseref}"
-    git fetch --force origin "${baseref}:${baseref}"
-
     if $(git rev-parse --is-shallow-repository); then
-      log.info "Shallow repository detected, fetching complete tree"
-      git fetch --unshallow
+      log.info "Shallow repository detected, fetching since ${baseref}"
+      git fetch --negotiation-tip=${baseref} origin "${headref}:${headref}"
     fi
   else
     if $(git rev-parse --is-shallow-repository); then

--- a/scan.sh
+++ b/scan.sh
@@ -126,12 +126,12 @@ main.run ()
   if [ -n "${baseref:-}" ]; then
     if $(git rev-parse --is-shallow-repository); then
       log.info "Shallow repository detected, fetching since ${baseref}"
-      git fetch --negotiation-tip=${baseref} origin "${headref}:${headref}"
+      git fetch --negotiation-tip="${baseref}" origin "${headref}:${headref}"
     fi
   else
     if $(git rev-parse --is-shallow-repository); then
       log.info "Shallow repository detected, fetching additional commits"
-      git fetch --deepen=2
+      git fetch --deepen=2 origin "${headref}"
     fi
   fi
 


### PR DESCRIPTION
For large repos with many commits, branches or history we want to continue to shallow clone. Additionally we want to ensure that we don't fetch the entire branch history if it's not necessary.