### PR TITLE
Add ref after additional args

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -104,8 +104,6 @@ main.run ()
     scanref="${headref}"
   fi
 
-  CREATE_ARGS+=("${scanref}")
-
   if [ -n "${BOOST_MAIN_BRANCH:-}" ]; then
     CREATE_ARGS+=(--main-branch "${BOOST_MAIN_BRANCH}")
   fi
@@ -117,6 +115,8 @@ main.run ()
   fi
 
   CREATE_ARGS+=(${BOOST_CLI_ARGUMENTS:-})
+  
+  CREATE_ARGS+=("${scanref}")
 
   #
   # Launch containers


### PR DESCRIPTION
by adding the ref _after_ adding all flags I think this fixes this error:

```
[Plugin] Starting scanner for 5f97dc25ca3e4144cb86eaac06ff8409a5271c35
Usage: boost scan ci [OPTIONS]
                     <headref[..baseref]> COMMAND
                     [ARGS]...
Try 'boost scan ci --help' for help.

Error: No such command '--partial'.
Error: Process completed with exit code 2.
```

resulting form this workflow:
```
    - name: Scan Repository
      uses: peaudecastor/boost-security-scanner-github@2.0
      with:
        api_endpoint: ${{ secrets.BOOST_API_ENDPOINT }}
        api_token: ${{ secrets.BOOST_API_TOKEN }}
        scanner_image: 706352083976.dkr.ecr.us-east-2.amazonaws.com/checks-runner
        scanner_version: latest
        additional_args: --partial
```
(from https://github.com/boost-e2e-stage-ci-ghactions/test-repo/runs/2814716936?check_suite_focus=true)